### PR TITLE
Fixed the "settings.yaml" file path for linux

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 dist/
+*.egg-info/
 *.pyc

--- a/MarkupViewer.py
+++ b/MarkupViewer.py
@@ -3,12 +3,14 @@
 
 from __future__ import print_function
 import sys, time, os, webbrowser, importlib, itertools, locale, io, subprocess, threading, shutil
+import platform
 try:
     import yaml
 except ImportError:
     yaml = None
 from PyQt4 import QtCore, QtGui, QtWebKit
 
+os_name        = platform.system() # 'Linux' or 'Windows'
 sys_enc        = locale.getpreferredencoding()
 script_dir     = os.path.dirname(os.path.realpath(__file__))
 stylesheet_dir = os.path.join(script_dir, 'stylesheets/')
@@ -488,7 +490,14 @@ class WatcherThread(QtCore.QThread):
 
 class Settings:
     def __init__(self):
-        self.user_source = os.path.join(os.getenv('APPDATA'), 'MarkupViewer/settings.yaml')
+        if(os_name == 'Linux'):
+            self.user_source = os.path.expanduser('~') + '/.MarkupViewer/settings.yaml'
+        elif(os_name == 'Windows'):
+            self.user_source = os.path.join(os.getenv('APPDATA' ,'MarkupViewer/settings.yaml'))
+        else:
+            self.user_source = 'MarkupViewer/settings.yaml'
+        # print(self.user_source)
+
         self.app_source  = os.path.join(script_dir, 'settings.yaml')
         self.settings_file = self.user_source if os.path.exists(self.user_source) else self.app_source
         self.reload_settings()


### PR DESCRIPTION
The version of my python2 was `2.7.8`
I typed `python2 MarkupViewer.py README.md` in Archlinux,but it show me this.

``` bash
$ python2 MarkupViewer.py README.md
Traceback (most recent call last):
  File "MarkupViewer.py", line 527, in <module>
    class SetuptheReader:
  File "MarkupViewer.py", line 541, in SetuptheReader
    'textile' : 'textile'
  File "MarkupViewer.py", line 501, in get
    return cls().settings.get(key, default_value)
  File "MarkupViewer.py", line 494, in __init__
    self.user_source = os.path.join(os.getenv('APPDATA'), 'MarkupViewer/settings.yaml')
  File "/usr/lib/python2.7/posixpath.py", line 77, in join
    elif path == '' or path.endswith('/'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```

The "APPDATA" was a Windows env.I hope It would‘nt read the env 'APPDATA' in Linux,so I changed the code.
